### PR TITLE
Change README.md to reflect new script location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Let's Encrypt automation for NearlyFreeSpeech
 
 ```sh
-git clone https://github.com/Celti/lets-nfsn.sh.git
+git clone https://github.com/nfsn/lets-nfsn.sh.git
 cd lets-nfsn.sh
 ./nfsn-setup.sh
 ```
 
 Follow the instructions on-screen from there.
+
+For more information, go to the member forums at NearlyFreeSpeech.net and see the posts about this script.


### PR DESCRIPTION
Now that NFSN has forked this script, the readme should provide instructions for running the forked, and NFSN-semi-supported, script, not the abandoned original script.
