### PR TITLE
Fix missing -q flag in grep

### DIFF
--- a/tls-setup.sh
+++ b/tls-setup.sh
@@ -86,7 +86,7 @@ fi
 
 /usr/local/bin/dehydrated --cron >${BASEDIR}/dehydrated.out
 
-if fgrep -v INFO: "${BASEDIR}/dehydrated.out" | fgrep -v unchanged | fgrep -v 'Skipping renew' | fgrep -v 'Checking expire date' | egrep -v '^Processing' || [ "${Verbose}" = "yes" ]
+if fgrep -v INFO: "${BASEDIR}/dehydrated.out" | fgrep -v unchanged | fgrep -v 'Skipping renew' | fgrep -v 'Checking expire date' | egrep -q -v '^Processing' || [ "${Verbose}" = "yes" ]
 then
 	cat "${BASEDIR}/dehydrated.out"
 fi


### PR DESCRIPTION
In [this upstream commit](ee2b90315d3eef639d72d448d5f06e0253c4e907) where changes were incorporated manually from
[my commit](ed0754b243bfc8568d321b0015b0f4f730b36848) the `-q` flag on the first of the two changed `grep`
lines was omitted, which means it will spill extra error-lines before
outputting the entire log.