### PR TITLE
fail on incorrect acme-challenge dir

### DIFF
--- a/tls-setup.sh
+++ b/tls-setup.sh
@@ -104,17 +104,17 @@ do
 		then
 			echo "Creating .well-known directory for ${Alias}."
 			mkdir "${AliasWellKnown}"
-			ACMEChallenge="${AliasWellKnown}/acme-challenge"
-			if [ ! -h "${ACMEChallenge}" ]
+		fi
+		ACMEChallenge="${AliasWellKnown}/acme-challenge"
+		if [ ! -h "${ACMEChallenge}" ]
+		then
+			if [ -e "${ACMEChallenge}" ]
 			then
-				if [ -e "${ACMEChallenge}" ]
-				then
-					echo "Please remove existing ${ACMEChallenge} to use this script." >&2
-					return 40
-				fi
-				echo "Linking acme-challenge for ${Alias}."
-				ln -s ../../.well-known/acme-challenge ${ACMEChallenge}
+				echo "Please remove existing ${ACMEChallenge} to use this script." >&2
+				return 40
 			fi
+			echo "Linking acme-challenge for ${Alias}."
+			ln -s ../../.well-known/acme-challenge ${ACMEChallenge}
 		fi
 	fi
 	if [ "${Reinstall}" = "yes" ]


### PR DESCRIPTION
With per-alias document root, the expected directory structure is:

```
/home/public/$ALIAS
└── .well-known
    └── acme-challenge -> ../../.well-known/acme-challenge
```

Prior to this change, this incorrect directory structure was not caught and would cause errors when performing the challenge:

```
/home/public/$ALIAS
└── .well-known
    └── acme-challenge
```

Now, a clear error is produced instead:

Please remove existing /home/public/$ALIAs/.well-known/acme-challenge to use this script.

----

Testing:

```
$ mkdir {a,b,c}.sam.seattle.wa.us
$ mkdir -p c.sam.seattle.wa.us/.well-known/acme-challenge
$ ln -s ../.well-known b.sam.seattle.wa.us/.well-known
$ tree -a {a,b,c}.sam.seattle.wa.us
a.sam.seattle.wa.us
b.sam.seattle.wa.us
└── .well-known -> ../.well-known
c.sam.seattle.wa.us
└── .well-known
    └── acme-challenge

5 directories, 0 files
$ ../private/tls-setup.sh 
Creating .well-known directory for a.sam.seattle.wa.us.
Linking acme-challenge for a.sam.seattle.wa.us.
Upgrading /home/public/b.sam.seattle.wa.us/.well-known
Creating .well-known directory for b.sam.seattle.wa.us.
Linking acme-challenge for b.sam.seattle.wa.us.
Please remove existing /home/public/c.sam.seattle.wa.us/.well-known/acme-challenge to use this script.
$ tree -a {a,b,c}.sam.seattle.wa.us
a.sam.seattle.wa.us
└── .well-known
    └── acme-challenge -> ../../.well-known/acme-challenge
b.sam.seattle.wa.us
└── .well-known
    └── acme-challenge -> ../../.well-known/acme-challenge
c.sam.seattle.wa.us
└── .well-known
    └── acme-challenge

9 directories, 0 files
```